### PR TITLE
Adds a cff file for GitHub autogenerated citations

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,6 @@
+cff-version: 1.2.0
+title: Hatchet Tutorial
+message: "If you use this software, please cite it as below."
+type: software
+date-released: "2021-11-11"
+url: https://github.com/LLNL/hatchet-tutorial

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,4 +3,7 @@ title: Hatchet Tutorial
 message: "If you use this software, please cite it as below."
 type: software
 date-released: "2021-11-11"
-url: https://github.com/LLNL/hatchet-tutorial
+repository-code: https://github.com/LLNL/hatchet-tutorial
+authors:
+  - given-names: Stephanie
+    family-names: Brink

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 title: Hatchet Tutorial
 message: "If you use this software, please cite it as below."
 type: software
-date-released: "2021-11-11"
+date-released: "2021-11-15"
 repository-code: https://github.com/LLNL/hatchet-tutorial
 authors:
   - given-names: Stephanie


### PR DESCRIPTION
This PR adds a citation file format (cff) file to activate GitHub's (relatively) new citation generation feature.